### PR TITLE
#include <vector>

### DIFF
--- a/include/copc-lib/hierarchy/key.hpp
+++ b/include/copc-lib/hierarchy/key.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <functional> // for hash
 #include <sstream>
+#include <vector>
 
 namespace copc
 {


### PR DESCRIPTION
AppleClang 11.0.3.11030032 complains that <vector> is not available.