### PR TITLE
Pin clang format version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     -   id: clang-format
         always_run: true
         args: ["-i"]
-        additional_dependencies: ["clang-format"]
+        additional_dependencies: ["clang-format==12.0.1"]
 -   repo: https://github.com/psf/black
     rev: 21.9b0
     hooks:


### PR DESCRIPTION
Clang-format locally and on CI keep fighting over formatting over some files. I'm pinning the version of clang-format to try and fix that.